### PR TITLE
Add API_CREDENTIAL category type

### DIFF
--- a/src/onepasswordconnectsdk/models/item.py
+++ b/src/onepasswordconnectsdk/models/item.py
@@ -190,7 +190,7 @@ class Item(object):
         :param category: The category of this Item.  # noqa: E501
         :type: str
         """
-        allowed_values = ["LOGIN", "PASSWORD", "SERVER", "DATABASE", "CREDIT_CARD", "MEMBERSHIP", "PASSPORT", "SOFTWARE_LICENSE", "OUTDOOR_LICENSE", "SECURE_NOTE", "WIRELESS_ROUTER", "BANK_ACCOUNT", "DRIVER_LICENSE", "IDENTITY", "REWARD_PROGRAM", "DOCUMENT", "EMAIL_ACCOUNT", "SOCIAL_SECURITY_NUMBER", "CUSTOM"]  # noqa: E501
+        allowed_values = ["LOGIN", "PASSWORD", "SERVER", "DATABASE", "CREDIT_CARD", "MEMBERSHIP", "PASSPORT", "SOFTWARE_LICENSE", "OUTDOOR_LICENSE", "SECURE_NOTE", "WIRELESS_ROUTER", "BANK_ACCOUNT", "DRIVER_LICENSE", "IDENTITY", "REWARD_PROGRAM", "DOCUMENT", "EMAIL_ACCOUNT", "SOCIAL_SECURITY_NUMBER", "API_CREDENTIAL", "CUSTOM"]  # noqa: E501
         if category not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `category` ({0}), must be one of {1}"  # noqa: E501

--- a/src/onepasswordconnectsdk/models/summary_item.py
+++ b/src/onepasswordconnectsdk/models/summary_item.py
@@ -180,7 +180,7 @@ class SummaryItem(object):
         :param category: The category of this Item.  # noqa: E501
         :type: str
         """
-        allowed_values = ["LOGIN", "PASSWORD", "SERVER", "DATABASE", "CREDIT_CARD", "MEMBERSHIP", "PASSPORT", "SOFTWARE_LICENSE", "OUTDOOR_LICENSE", "SECURE_NOTE", "WIRELESS_ROUTER", "BANK_ACCOUNT", "DRIVER_LICENSE", "IDENTITY", "REWARD_PROGRAM", "DOCUMENT", "EMAIL_ACCOUNT", "SOCIAL_SECURITY_NUMBER", "CUSTOM"]  # noqa: E501
+        allowed_values = ["LOGIN", "PASSWORD", "SERVER", "DATABASE", "CREDIT_CARD", "MEMBERSHIP", "PASSPORT", "SOFTWARE_LICENSE", "OUTDOOR_LICENSE", "SECURE_NOTE", "WIRELESS_ROUTER", "BANK_ACCOUNT", "DRIVER_LICENSE", "IDENTITY", "REWARD_PROGRAM", "DOCUMENT", "EMAIL_ACCOUNT", "SOCIAL_SECURITY_NUMBER", "API_CREDENTIAL", "CUSTOM"]  # noqa: E501
         if category not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `category` ({0}), must be one of {1}"  # noqa: E501


### PR DESCRIPTION
This PR adds the `API_CREDENTIAL` category type to the list of categories supported by the SDK.

Fixes #13 