### PR TITLE
Fix error where field expects TOTP type rather than OTP

### DIFF
--- a/src/onepasswordconnectsdk/models/field.py
+++ b/src/onepasswordconnectsdk/models/field.py
@@ -139,7 +139,7 @@ class Field(object):
         :param type: The type of this Field.  # noqa: E501
         :type: str
         """
-        allowed_values = ["STRING", "EMAIL", "CONCEALED", "URL", "TOTP", "DATE", "MONTH_YEAR", "MENU"]  # noqa: E501
+        allowed_values = ["STRING", "EMAIL", "CONCEALED", "URL", "OTP", "DATE", "MONTH_YEAR", "MENU"]  # noqa: E501
         if type not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `type` ({0}), must be one of {1}"  # noqa: E501


### PR DESCRIPTION
Resolves https://github.com/1Password/connect-sdk-python/issues/12, however this issue also revealed another issue in Connect, thus will need to be running Connect version 1.2 to be able to successfully use OTP.