### PR TITLE
Add TOTP field for the Field class

### DIFF
--- a/src/onepasswordconnectsdk/models/field.py
+++ b/src/onepasswordconnectsdk/models/field.py
@@ -38,7 +38,8 @@ class Field(object):
         'label': 'str',
         'value': 'str',
         'generate': 'bool',
-        'entropy': 'float'
+        'entropy': 'float',
+        'totp': 'str'
     }
 
     attribute_map = {
@@ -49,10 +50,11 @@ class Field(object):
         'label': 'label',
         'value': 'value',
         'generate': 'generate',
-        'entropy': 'entropy'
+        'entropy': 'entropy',
+        'totp': 'str'
     }
 
-    def __init__(self, id=None, section=None, type='STRING', purpose=None, label=None, value=None, generate=False, entropy=None):  # noqa: E501
+    def __init__(self, id=None, section=None, type='STRING', purpose=None, label=None, value=None, generate=False, entropy=None, totp=None):  # noqa: E501
         self._id = None
         self._section = None
         self._type = None
@@ -62,6 +64,7 @@ class Field(object):
         self._generate = None
         self._entropy = None
         self.discriminator = None
+        self.totp = None
 
         self.id = id
         if section is not None:
@@ -78,6 +81,8 @@ class Field(object):
             self.generate = generate
         if entropy is not None:
             self.entropy = entropy
+        if totp is not None:
+            self.totp = totp
 
     @property
     def id(self):
@@ -264,6 +269,28 @@ class Field(object):
         """
 
         self._entropy = entropy
+    
+    @property
+    def totp(self):
+        """Gets the TOTP. # noqa: E501
+        
+        For fields of type 'OTP' this is the one-time password code # noqa: E501
+
+        :return: The TOTP of the Field. # noqa: E501
+        :rtype: str
+        """
+    
+    @totp.setter
+    def totp(self, totp):
+        """Sets the totp of this Field.
+
+        For fields of type 'OTP' this is the one-time password code # noqa: E501
+
+        :param totp: The TOTP of this Field.  # noqa: E501
+        :type: str
+        """
+
+        self._totp = totp
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/src/onepasswordconnectsdk/models/field.py
+++ b/src/onepasswordconnectsdk/models/field.py
@@ -51,7 +51,7 @@ class Field(object):
         'value': 'value',
         'generate': 'generate',
         'entropy': 'entropy',
-        'totp': 'str'
+        'totp': 'totp'
     }
 
     def __init__(self, id=None, section=None, type='STRING', purpose=None, label=None, value=None, generate=False, entropy=None, totp=None):  # noqa: E501
@@ -63,8 +63,8 @@ class Field(object):
         self._value = None
         self._generate = None
         self._entropy = None
+        self._totp = None
         self.discriminator = None
-        self.totp = None
 
         self.id = id
         if section is not None:
@@ -279,6 +279,7 @@ class Field(object):
         :return: The TOTP of the Field. # noqa: E501
         :rtype: str
         """
+        return self._totp
     
     @totp.setter
     def totp(self, totp):

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -263,18 +263,18 @@ def compare_items(expected_item, returned_item):
 
 
 def compare_fields(expected_field, returned_field):
-    assert expected_field["id"] == returned_field.id
-    assert expected_field["label"] == returned_field.label
-    assert expected_field["value"] == returned_field.value
-    assert expected_field["purpose"] == returned_field.purpose
-    assert expected_field["section"]["id"] == returned_field.section.id
-    assert expected_field["type"] == returned_field.type
-    assert expected_field["totp"] == returned_field.totp
+    assert expected_field.get("id") == returned_field.id
+    assert expected_field.get("label") == returned_field.label
+    assert expected_field.get("value") == returned_field.value
+    assert expected_field.get("purpose") == returned_field.purpose
+    assert expected_field.get("section").get("id") == returned_field.section.id
+    assert expected_field.get("type") == returned_field.type
+    assert expected_field.get("totp") == returned_field.totp
 
 
 def compare_sections(expected_section, returned_section):
-    assert expected_section["id"] == returned_section.id
-    assert expected_section["label"] == returned_section.label
+    assert expected_section.get("id") == returned_section.id
+    assert expected_section.get("label") == returned_section.label
 
 
 def get_items():

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -269,6 +269,7 @@ def compare_fields(expected_field, returned_field):
     assert expected_field["purpose"] == returned_field.purpose
     assert expected_field["section"]["id"] == returned_field.section.id
     assert expected_field["type"] == returned_field.type
+    assert expected_field["totp"] == returned_field.totp
 
 
 def compare_sections(expected_section, returned_section):
@@ -331,6 +332,16 @@ def get_item():
                 "type": "STRING",
                 "label": "something",
                 "value": "test"
+            },
+            {
+                "id": "TOTP_acf2fgvsa312c9sd4vs8jhkli",
+                "section": {
+                    "id": "Section_47DC4DDBF26640AB8B8618DA36D5A492"
+                },
+                "type": "OTP",
+                "label": "one-time password",
+                "value": "otpauth://totp=testop?secret=test",
+                "totp": "134253"
             }
         ],
         "lastEditedBy": "DOIHOHSV2NHK5HMSOLCWJUXFDM",


### PR DESCRIPTION
Starting with Connect 1.4.0 we introduced the capability to get the totp value through Connect. Now the SDK supports that as well.
