### PR TITLE
Address injection vector in GitHub Action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Parse release version
         id: get_version
-        run: echo "::set-output name=version::$(echo "${GITHUB_REF}" | sed 's|^refs/heads/release/v?*||g')"
+        run: echo "::set-output name=version::`echo "${GITHUB_REF}" | sed 's|^refs/heads/release/v?*||g'`"
 
       - name: Prepare Pull Request
         id: prep_pr

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Parse release version
         id: get_version
-        run: echo "::set-output name=version::$(echo $GITHUB_REF | sed 's|^refs/heads/release/v?*||g')"
+        run: echo "::set-output name=version::$(echo "${GITHUB_REF}" | sed 's|^refs/heads/release/v?*||g')"
 
       - name: Prepare Pull Request
         id: prep_pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,10 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Create Release tag
         id: create-tag
+        env:
+          PR_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          release_tag=$(echo ${{ github.event.pull_request.head.ref }} | cut -d "/" -f2)
+          release_tag=$(echo "$PR_REF" | cut -d "/" -f2)
           echo "::set-output name=release-tag::$release_tag"
       - name: Make new release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
A Bugcrowd researcher submitted a report that our workflow didn't properly sanitize the Git ref name in its workflow. Since a contributor to this code can set e.g. their branch name arbitrarily, this could be used to inject commands here.

While the impact is mitigated by the fact that Actions need approval before running, and it should be stated we haven't seen any attempts here, this is still an important oversight. This PR addresses that.