### PR TITLE
fix: correctly handle section objects with None type labels

### DIFF
--- a/src/onepasswordconnectsdk/config.py
+++ b/src/onepasswordconnectsdk/config.py
@@ -193,17 +193,20 @@ def _set_values_for_item(
                 section_id = field.section.id
             except AttributeError:
                 section_id = None
+                
+            if field.label == path_parts[1]:
+                if (
+                    section_id is None
+                    or (section_id == sections.get(path_parts[0]))
+                    or path_parts[0] in sections.values()
+                ):
+                    value_found = True
 
-            if field.label == path_parts[1] and (
-                section_id is None or section_id == sections[path_parts[0]]
-            ):
-                value_found = True
-
-                if config_object:
-                    setattr(config_object, parsed_field.name, field.value)
-                else:
-                    config_dict[parsed_field.name] = field.value
-                break
+                    if config_object:
+                        setattr(config_object, parsed_field.name, field.value)
+                    else:
+                        config_dict[parsed_field.name] = field.value
+                    break
         if not value_found:
             raise UnknownSectionAndFieldTag(
                 f"There is no section {path_parts[0]} \
@@ -214,6 +217,7 @@ def _set_values_for_item(
 def _convert_sections_to_dict(sections: List[Section]):
     if not sections:
         return {}
+
     section_dict = {section.label: section.id for section in sections}
     return section_dict
 


### PR DESCRIPTION
This fixes an issue we ran into where additional field items added to a 1Password vault item through the 'add more' dropdown in the GUI causes the section to be added with a `None` type label that looks like: `'sections': [{'id': 'add more', 'label': None}],`

![image](https://user-images.githubusercontent.com/41876089/198703800-b4db8dc2-a0c8-41c8-af1d-47a1de51c069.png)

This breaks the ability to access this field using the `load_dict` function, as that function takes in a field path `some_section.someField`, splits it at the `.` and uses the first index in that split array as the key to access a dict that looks like `{section.label: section.id}` 

This causes the section to never be accessible because it's impossible for `path_parts[0]` to be of `None` type

I'm unsure if this is just an edge-case that wasn't accounted for, or a possible bug in the GUI when adding a 'add more' section to a vault item, but, using the section.id in place of the label if the label happens to be `None` allowed us to properly access these fields again
