### PR TITLE
Remove hard-coded checks for item category and field type

### DIFF
--- a/src/onepasswordconnectsdk/models/field.py
+++ b/src/onepasswordconnectsdk/models/field.py
@@ -144,13 +144,6 @@ class Field(object):
         :param type: The type of this Field.  # noqa: E501
         :type: str
         """
-        allowed_values = ["STRING", "EMAIL", "CONCEALED", "URL", "OTP", "DATE", "MONTH_YEAR", "MENU"]  # noqa: E501
-        if type not in allowed_values:  # noqa: E501
-            raise ValueError(
-                "Invalid value for `type` ({0}), must be one of {1}"  # noqa: E501
-                .format(type, allowed_values)
-            )
-
         self._type = type
 
     @property

--- a/src/onepasswordconnectsdk/models/item.py
+++ b/src/onepasswordconnectsdk/models/item.py
@@ -190,13 +190,6 @@ class Item(object):
         :param category: The category of this Item.  # noqa: E501
         :type: str
         """
-        allowed_values = ["LOGIN", "PASSWORD", "SERVER", "DATABASE", "CREDIT_CARD", "MEMBERSHIP", "PASSPORT", "SOFTWARE_LICENSE", "OUTDOOR_LICENSE", "SECURE_NOTE", "WIRELESS_ROUTER", "BANK_ACCOUNT", "DRIVER_LICENSE", "IDENTITY", "REWARD_PROGRAM", "DOCUMENT", "EMAIL_ACCOUNT", "SOCIAL_SECURITY_NUMBER", "API_CREDENTIAL", "CUSTOM"]  # noqa: E501
-        if category not in allowed_values:  # noqa: E501
-            raise ValueError(
-                "Invalid value for `category` ({0}), must be one of {1}"  # noqa: E501
-                .format(category, allowed_values)
-            )
-
         self._category = category
 
     @property

--- a/src/onepasswordconnectsdk/models/summary_item.py
+++ b/src/onepasswordconnectsdk/models/summary_item.py
@@ -182,13 +182,6 @@ class SummaryItem(object):
         :param category: The category of this Item.  # noqa: E501
         :type: str
         """
-        allowed_values = ["LOGIN", "PASSWORD", "SERVER", "DATABASE", "CREDIT_CARD", "MEMBERSHIP", "PASSPORT", "SOFTWARE_LICENSE", "OUTDOOR_LICENSE", "SECURE_NOTE", "WIRELESS_ROUTER", "BANK_ACCOUNT", "DRIVER_LICENSE", "IDENTITY", "REWARD_PROGRAM", "DOCUMENT", "EMAIL_ACCOUNT", "SOCIAL_SECURITY_NUMBER", "API_CREDENTIAL", "CUSTOM"]  # noqa: E501
-        if category not in allowed_values:  # noqa: E501
-            raise ValueError(
-                "Invalid value for `category` ({0}), must be one of {1}"  # noqa: E501
-                .format(category, allowed_values)
-            )
-
         self._category = category
 
     @property


### PR DESCRIPTION
Because these checks are also applied during deserialization of Connect's JSON response, they can cause the SDK to return an error if a new category or field type is added in Connect.

Removing these checks should not lead to problems as Connect already validates these fields.