### PR TITLE
Use content_path url to fetch the file content

### DIFF
--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -76,8 +76,8 @@ class Client:
             )
         return self.deserialize(response.content, "list[File]")
 
-    def get_file_content(self, file_id: str, item_id: str, vault_id: str):
-        url = f"/v1/vaults/{vault_id}/items/{item_id}/files/{file_id}/content"
+    def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None):
+        url = content_path if content_path is not None else f"/v1/vaults/{vault_id}/items/{item_id}/files/{file_id}/content"
 
         response = self.build_request("GET", url)
         try:
@@ -91,8 +91,8 @@ class Client:
 
     def download_file(self, file_id: str, item_id: str, vault_id: str, path: str):
         file_object = self.get_file(file_id, item_id, vault_id)
-        filename = file_object.name
-        content = self.get_file_content(file_id, item_id, vault_id)
+        filename = file_object.name or "1password_item_file.txt"
+        content = self.get_file_content(file_id, item_id, vault_id, file_object.content_path)
         global_path = os.path.join(path, filename)
 
         file = open(global_path, "wb")


### PR DESCRIPTION
Resolves #46 

The Connect server version 1.5.4 and 1.5.5 has an issue with the file id.
The id property of the file is different than the file_id used to fetch file content (`/v1/vaults/<vault_id>/items/<item_id>/files/<file_id>/content`), but it should be the same.
Starting from Connect v1.5.6 this issue is resolved and id and file_id has the same value.

This PR provides the fix for the users that use Connect v1.5.4 and v1.5.5.
We started to use `content_path` value which always contains the correct url to fetch the file content.