### PR TITLE
Add return types to client functions.

### DIFF
--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -70,8 +70,8 @@ class AsyncClient:
             )
         return response.content
 
-    async def download_file(self, file_id: str, item_id: str, vault_id: str, path: str):
-        file_object = await self.get_file(file_id, item_id, vault_id) 
+    async def download_file(self, file_id: str, item_id: str, vault_id: str, path: str) -> None:
+        file_object = await self.get_file(file_id, item_id, vault_id)
         filename = file_object.name or "1password_item_file.txt"
         content = await self.get_file_content(file_id, item_id, vault_id, file_object.content_path)
         global_path = os.path.join(path, filename)

--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -2,7 +2,7 @@
 import httpx
 from httpx import HTTPError
 import json
-from typing import Dict, List
+from typing import Dict, List, Union
 import os
 
 from onepasswordconnectsdk.serializer import Serializer
@@ -57,7 +57,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "list[File]")
 
-    async def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> bytes | str:
+    async def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> Union[bytes, str]:
         url = content_path
         if content_path is None:
             url = PathBuilder().vaults(vault_id).items(item_id).files(file_id).content().build()

--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -2,6 +2,7 @@
 import httpx
 from httpx import HTTPError
 import json
+from typing import Dict, List
 import os
 
 from onepasswordconnectsdk.serializer import Serializer
@@ -26,7 +27,7 @@ class AsyncClient:
     def create_session(self, url: str, token: str) -> httpx.AsyncClient:
         return httpx.AsyncClient(base_url=url, headers=self.build_headers(token))
 
-    def build_headers(self, token: str) -> dict[str, str]:
+    def build_headers(self, token: str) -> Dict[str, str]:
         return build_headers(token)
 
     async def __aexit__(self):
@@ -44,7 +45,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "File")
 
-    async def get_files(self, item_id: str, vault_id: str) -> list[File]:
+    async def get_files(self, item_id: str, vault_id: str) -> List[File]:
         url = PathBuilder().vaults(vault_id).items(item_id).files().build()
         response = await self.build_request("GET", url)
         try:
@@ -164,7 +165,7 @@ class AsyncClient:
         item_summary = self.serializer.deserialize(response.content, "list[SummaryItem]")[0]
         return await self.get_item_by_id(item_summary.id, vault_id)
 
-    async def get_items(self, vault_id: str, filter_query: str = None) -> list[SummaryItem]:
+    async def get_items(self, vault_id: str, filter_query: str = None) -> List[SummaryItem]:
         """Returns a list of item summaries for the specified vault
 
         Args:
@@ -326,7 +327,7 @@ class AsyncClient:
 
         return self.serializer.deserialize(response.content, "list[Vault]")[0]
 
-    async def get_vaults(self) -> list[Vault]:
+    async def get_vaults(self) -> List[Vault]:
         """Returns all vaults for service account set in client
 
         Raises:

--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -10,29 +10,29 @@ from onepasswordconnectsdk.errors import (
     FailedToRetrieveItemException,
     FailedToRetrieveVaultException,
 )
-from onepasswordconnectsdk.models import Item, ItemVault
+from onepasswordconnectsdk.models import File, Item, ItemVault, SummaryItem, Vault
 
 
 class AsyncClient:
     """Python Async Client Class"""
 
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str) -> None:
         """Initialize async client"""
         self.url = url
         self.token = token
         self.session = self.create_session(url, token)
         self.serializer = Serializer()
 
-    def create_session(self, url: str, token: str):
+    def create_session(self, url: str, token: str) -> httpx.AsyncClient:
         return httpx.AsyncClient(base_url=url, headers=self.build_headers(token))
 
-    def build_headers(self, token: str):
+    def build_headers(self, token: str) -> dict[str, str]:
         return build_headers(token)
 
     async def __aexit__(self):
         await self.session.aclose()
 
-    async def get_file(self, file_id: str, item_id: str, vault_id: str):
+    async def get_file(self, file_id: str, item_id: str, vault_id: str) -> File:
         url = PathBuilder().vaults(vault_id).items(item_id).files(file_id).build()
         response = await self.build_request("GET", url)
         try:
@@ -44,7 +44,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "File")
 
-    async def get_files(self, item_id: str, vault_id: str):
+    async def get_files(self, item_id: str, vault_id: str) -> list[File]:
         url = PathBuilder().vaults(vault_id).items(item_id).files().build()
         response = await self.build_request("GET", url)
         try:
@@ -56,7 +56,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "list[File]")
 
-    async def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None):
+    async def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> bytes | str:
         url = content_path
         if content_path is None:
             url = PathBuilder().vaults(vault_id).items(item_id).files(file_id).content().build()
@@ -71,7 +71,7 @@ class AsyncClient:
         return response.content
 
     async def download_file(self, file_id: str, item_id: str, vault_id: str, path: str):
-        file_object = await self.get_file(file_id, item_id, vault_id)
+        file_object = await self.get_file(file_id, item_id, vault_id) 
         filename = file_object.name or "1password_item_file.txt"
         content = await self.get_file_content(file_id, item_id, vault_id, file_object.content_path)
         global_path = os.path.join(path, filename)
@@ -80,7 +80,7 @@ class AsyncClient:
         file.write(content)
         file.close()
 
-    async def get_item(self, item: str, vault: str):
+    async def get_item(self, item: str, vault: str) -> Item:
         """Get a specific item
 
         Args:
@@ -105,7 +105,7 @@ class AsyncClient:
         else:
             return await self.get_item_by_title(item, vault_id)
 
-    async def get_item_by_id(self, item_id: str, vault_id: str):
+    async def get_item_by_id(self, item_id: str, vault_id: str) -> Item:
         """Get a specific item by uuid
 
         Args:
@@ -130,7 +130,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "Item")
 
-    async def get_item_by_title(self, title: str, vault_id: str):
+    async def get_item_by_title(self, title: str, vault_id: str) -> Item:
         """Get a specific item by title
 
         Args:
@@ -164,7 +164,7 @@ class AsyncClient:
         item_summary = self.serializer.deserialize(response.content, "list[SummaryItem]")[0]
         return await self.get_item_by_id(item_summary.id, vault_id)
 
-    async def get_items(self, vault_id: str, filter_query: str = None):
+    async def get_items(self, vault_id: str, filter_query: str = None) -> list[SummaryItem]:
         """Returns a list of item summaries for the specified vault
 
         Args:
@@ -192,7 +192,7 @@ class AsyncClient:
 
         return self.serializer.deserialize(response.content, "list[SummaryItem]")
 
-    async def delete_item(self, item_id: str, vault_id: str):
+    async def delete_item(self, item_id: str, vault_id: str) -> None:
         """Deletes a specified item from a specified vault
 
         Args:
@@ -214,7 +214,7 @@ class AsyncClient:
                      for {url} with message: {response.json().get('message')}"
             )
 
-    async def create_item(self, vault_id: str, item: Item):
+    async def create_item(self, vault_id: str, item: Item) -> Item:
         """Creates an item at the specified vault
 
         Args:
@@ -240,7 +240,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "Item")
 
-    async def update_item(self, item_uuid: str, vault_id: str, item: Item):
+    async def update_item(self, item_uuid: str, vault_id: str, item: Item) -> Item:
         """Update the specified item at the specified vault.
 
         Args:
@@ -269,7 +269,7 @@ class AsyncClient:
             )
         return self.serializer.deserialize(response.content, "Item")
 
-    async def get_vault(self, vault_id: str):
+    async def get_vault(self, vault_id: str) -> Vault:
         """Returns the vault with the given vault_id
 
         Args:
@@ -294,7 +294,7 @@ class AsyncClient:
 
         return self.serializer.deserialize(response.content, "Vault")
 
-    async def get_vault_by_title(self, name: str):
+    async def get_vault_by_title(self, name: str) -> Vault:
         """Returns the vault with the given name
 
         Args:
@@ -326,7 +326,7 @@ class AsyncClient:
 
         return self.serializer.deserialize(response.content, "list[Vault]")[0]
 
-    async def get_vaults(self):
+    async def get_vaults(self) -> list[Vault]:
         """Returns all vaults for service account set in client
 
         Raises:
@@ -348,7 +348,7 @@ class AsyncClient:
 
         return self.serializer.deserialize(response.content, "list[Vault]")
 
-    def build_request(self, method: str, path: str, body=None):
+    def build_request(self, method: str, path: str, body=None) -> httpx.Response:
         """Builds a http request
         Parameters:
         method (str): The rest method to be used

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -50,7 +50,7 @@ class Client:
                 f"Unable to retrieve item. Received {response.status_code}\
                                      for {url} with message: {response.json().get('message')}"
             )
-        return self.serializer.deserialize(response.content, "File")
+        return self.deserialize(response.content, "File")
 
     def get_files(self, item_id: str, vault_id: str) -> List[File]:
         url = PathBuilder().vaults(vault_id).items(item_id).files().build()
@@ -62,7 +62,10 @@ class Client:
                 f"Unable to retrieve item. Received {response.status_code}\
                              for {url} with message: {response.json().get('message')}"
             )
-        return self.serializer.deserialize(response.content, "list[File]")
+        return self.deserialize(response.content, "list[File]")
+
+    def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> str:
+        url = content_path if content_path is not None else f"/v1/vaults/{vault_id}/items/{item_id}/files/{file_id}/content"
 
     def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> Union[bytes, str]:
         url = content_path
@@ -135,7 +138,7 @@ class Client:
                 f"Unable to retrieve item. Received {response.status_code}\
                      for {url} with message: {response.json().get('message')}"
             )
-        return self.serializer.deserialize(response.content, "Item")
+        return self.deserialize(response.content, "Item")
 
     def get_item_by_title(self, title: str, vault_id: str) -> Item:
         """Get a specific item by title
@@ -199,7 +202,7 @@ class Client:
                      for {url} with message: {response.json().get('message')}"
             )
 
-        return self.serializer.deserialize(response.content, "list[SummaryItem]")
+        return self.deserialize(response.content, "list[SummaryItem]")
 
     def delete_item(self, item_id: str, vault_id: str) -> None:
         """Deletes a specified item from a specified vault
@@ -246,7 +249,7 @@ class Client:
                 f"Unable to post item. Received {response.status_code}\
                     for {url} with message: {response.json().get('message')}"
             )
-        return self.serializer.deserialize(response.content, "Item")
+        return self.deserialize(response.content, "Item")
 
     def update_item(self, item_uuid: str, vault_id: str, item: Item) -> Item:
         """Update the specified item at the specified vault.
@@ -275,7 +278,7 @@ class Client:
                 f"Unable to post item. Received {response.status_code}\
                     for {url} with message: {response.json().get('message')}"
             )
-        return self.serializer.deserialize(response.content, "Item")
+        return self.deserialize(response.content, "Item")
 
     def get_vault(self, vault_id: str) -> Vault:
         """Returns the vault with the given vault_id
@@ -300,7 +303,7 @@ class Client:
                      for {url} with message {response.json().get('message')}"
             )
 
-        return self.serializer.deserialize(response.content, "Vault")
+        return self.deserialize(response.content, "Vault")
 
     def get_vault_by_title(self, name: str) -> Vault:
         """Returns the vault with the given name
@@ -354,7 +357,7 @@ class Client:
                      for {url} with message {response.json().get('message')}"
             )
 
-        return self.serializer.deserialize(response.content, "list[Vault]")
+        return self.deserialize(response.content, "list[Vault]")
 
     def build_request(self, method: str, path: str, body=None) -> httpx.Response:
         """Builds a http request

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -64,9 +64,6 @@ class Client:
             )
         return self.deserialize(response.content, "list[File]")
 
-    def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> str:
-        url = content_path if content_path is not None else f"/v1/vaults/{vault_id}/items/{item_id}/files/{file_id}/content"
-
     def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> Union[bytes, str]:
         url = content_path
         if content_path is None:

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Union
 import httpx
 from httpx import HTTPError
 import json
-from typing import Dict, List
+from typing import Dict, List, Union
 import os
 
 from onepasswordconnectsdk.async_client import AsyncClient

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -117,7 +117,7 @@ class Client:
 
     def get_item_by_id(self, item_id: str, vault_id: str) -> Item:
         """Get a specific item by uuid
-       
+
         Args:
             item_id (str): The id of the item to be fetched
             vault_id (str): The id of the vault in which to get the item from
@@ -142,7 +142,7 @@ class Client:
 
     def get_item_by_title(self, title: str, vault_id: str) -> Item:
         """Get a specific item by title
-        
+
         Args:
             title (str): The title of the item to be fetched
             vault_id (str): The id of the vault in which to get the item from
@@ -307,10 +307,10 @@ class Client:
 
     def get_vault_by_title(self, name: str) -> Vault:
         """Returns the vault with the given name
-        
+
         Args:
             name (str): The name of the vault in which to fetch
-        
+
         Raises:
             FailedToRetrieveVaultException: Thrown when a HTTP error is
             returned from the 1Password Connect API

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -1,4 +1,5 @@
 """Python Client for connecting to 1Password Connect"""
+from typing import Dict, List, Union
 import httpx
 from httpx import HTTPError
 import json
@@ -13,7 +14,7 @@ from onepasswordconnectsdk.errors import (
     EnvironmentHostNotSetException,
     EnvironmentTokenNotSetException,
 )
-from onepasswordconnectsdk.models import Item, ItemVault
+from onepasswordconnectsdk.models import File, Item, ItemVault, SummaryItem, Vault
 from onepasswordconnectsdk.models.constants import CONNECT_HOST_ENV_VARIABLE
 
 ENV_SERVICE_ACCOUNT_JWT_VARIABLE = "OP_CONNECT_TOKEN"
@@ -23,23 +24,23 @@ ENV_IS_ASYNC_CLIENT = "OP_CONNECT_CLIENT_ASYNC"
 class Client:
     """Python Client Class"""
 
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str) -> None:
         """Initialize client"""
         self.url = url
         self.token = token
         self.session = self.create_session(url, token)
         self.serializer = Serializer()
 
-    def create_session(self, url: str, token: str):
+    def create_session(self, url: str, token: str) -> httpx.Client:
         return httpx.Client(base_url=url, headers=self.build_headers(token))
 
-    def build_headers(self, token: str):
+    def build_headers(self, token: str) -> Dict[str, str]:
         return build_headers(token)
 
     def __del__(self):
         self.session.close()
 
-    def get_file(self, file_id: str, item_id: str, vault_id: str):
+    def get_file(self, file_id: str, item_id: str, vault_id: str) -> File:
         url = PathBuilder().vaults(vault_id).items(item_id).files(file_id).build()
         response = self.build_request("GET", url)
         try:
@@ -51,7 +52,7 @@ class Client:
             )
         return self.serializer.deserialize(response.content, "File")
 
-    def get_files(self, item_id: str, vault_id: str):
+    def get_files(self, item_id: str, vault_id: str) -> List[File]:
         url = PathBuilder().vaults(vault_id).items(item_id).files().build()
         response = self.build_request("GET", url)
         try:
@@ -63,7 +64,7 @@ class Client:
             )
         return self.serializer.deserialize(response.content, "list[File]")
 
-    def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None):
+    def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> Union[bytes, str]:
         url = content_path
         if content_path is None:
             url = PathBuilder().vaults(vault_id).items(item_id).files(file_id).content().build()
@@ -77,7 +78,7 @@ class Client:
             )
         return response.content
 
-    def download_file(self, file_id: str, item_id: str, vault_id: str, path: str):
+    def download_file(self, file_id: str, item_id: str, vault_id: str, path: str) -> None:
         file_object = self.get_file(file_id, item_id, vault_id)
         filename = file_object.name or "1password_item_file.txt"
         content = self.get_file_content(file_id, item_id, vault_id, file_object.content_path)
@@ -87,7 +88,7 @@ class Client:
         file.write(content)
         file.close()
 
-    def get_item(self, item: str, vault: str):
+    def get_item(self, item: str, vault: str) -> Item:
         """Get a specific item
 
         Args:
@@ -111,7 +112,7 @@ class Client:
         else:
             return self.get_item_by_title(item, vault_id)
 
-    def get_item_by_id(self, item_id: str, vault_id: str):
+    def get_item_by_id(self, item_id: str, vault_id: str) -> Item:
         """Get a specific item by uuid
        
         Args:
@@ -136,7 +137,7 @@ class Client:
             )
         return self.serializer.deserialize(response.content, "Item")
 
-    def get_item_by_title(self, title: str, vault_id: str):
+    def get_item_by_title(self, title: str, vault_id: str) -> Item:
         """Get a specific item by title
         
         Args:
@@ -170,7 +171,7 @@ class Client:
         item_summary = self.serializer.deserialize(response.content, "list[SummaryItem]")[0]
         return self.get_item_by_id(item_summary.id, vault_id)
 
-    def get_items(self, vault_id: str, filter_query: str = None):
+    def get_items(self, vault_id: str, filter_query: str = None) -> list[SummaryItem]:
         """Returns a list of item summaries for the specified vault
 
         Args:
@@ -200,7 +201,7 @@ class Client:
 
         return self.serializer.deserialize(response.content, "list[SummaryItem]")
 
-    def delete_item(self, item_id: str, vault_id: str):
+    def delete_item(self, item_id: str, vault_id: str) -> None:
         """Deletes a specified item from a specified vault
 
         Args:
@@ -221,7 +222,7 @@ class Client:
                      for {url} with message: {response.json().get('message')}"
             )
 
-    def create_item(self, vault_id: str, item: Item):
+    def create_item(self, vault_id: str, item: Item) -> Item:
         """Creates an item at the specified vault
 
         Args:
@@ -247,7 +248,7 @@ class Client:
             )
         return self.serializer.deserialize(response.content, "Item")
 
-    def update_item(self, item_uuid: str, vault_id: str, item: Item):
+    def update_item(self, item_uuid: str, vault_id: str, item: Item) -> Item:
         """Update the specified item at the specified vault.
 
         Args:
@@ -276,7 +277,7 @@ class Client:
             )
         return self.serializer.deserialize(response.content, "Item")
 
-    def get_vault(self, vault_id: str):
+    def get_vault(self, vault_id: str) -> Vault:
         """Returns the vault with the given vault_id
 
         Args:
@@ -301,7 +302,7 @@ class Client:
 
         return self.serializer.deserialize(response.content, "Vault")
 
-    def get_vault_by_title(self, name: str):
+    def get_vault_by_title(self, name: str) -> Vault:
         """Returns the vault with the given name
         
         Args:
@@ -333,7 +334,7 @@ class Client:
 
         return self.serializer.deserialize(response.content, "list[Vault]")[0]
 
-    def get_vaults(self):
+    def get_vaults(self) -> list[Vault]:
         """Returns all vaults for service account set in client
 
         Raises:
@@ -355,7 +356,7 @@ class Client:
 
         return self.serializer.deserialize(response.content, "list[Vault]")
 
-    def build_request(self, method: str, path: str, body=None):
+    def build_request(self, method: str, path: str, body=None) -> httpx.Response:
         """Builds a http request
         Parameters:
         method (str): The rest method to be used
@@ -380,7 +381,7 @@ class Client:
         return self.serializer.sanitize_for_serialization(obj)
 
 
-def new_client(url: str, token: str, is_async: bool = False):
+def new_client(url: str, token: str, is_async: bool = False) -> Union[AsyncClient, Client]:
     """Builds a new client for interacting with 1Password Connect
     Parameters:
     url: The url of the 1Password Connect API
@@ -395,7 +396,7 @@ def new_client(url: str, token: str, is_async: bool = False):
     return Client(url, token)
 
 
-def new_client_from_environment(url: str = None):
+def new_client_from_environment(url: str = None) -> Union[AsyncClient, Client]:
     """Builds a new client for interacting with 1Password Connect
     using the OP_TOKEN environment variable
 

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -1,5 +1,4 @@
 """Python Client for connecting to 1Password Connect"""
-from typing import Dict, List, Union
 import httpx
 from httpx import HTTPError
 import json

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -37,7 +37,7 @@ class Client:
     def build_headers(self, token: str) -> Dict[str, str]:
         return build_headers(token)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.session.close()
 
     def get_file(self, file_id: str, item_id: str, vault_id: str) -> File:

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Union
 import httpx
 from httpx import HTTPError
 import json
+from typing import Dict, List
 import os
 
 from onepasswordconnectsdk.async_client import AsyncClient
@@ -171,7 +172,7 @@ class Client:
         item_summary = self.serializer.deserialize(response.content, "list[SummaryItem]")[0]
         return self.get_item_by_id(item_summary.id, vault_id)
 
-    def get_items(self, vault_id: str, filter_query: str = None) -> list[SummaryItem]:
+    def get_items(self, vault_id: str, filter_query: str = None) -> List[SummaryItem]:
         """Returns a list of item summaries for the specified vault
 
         Args:
@@ -334,7 +335,7 @@ class Client:
 
         return self.serializer.deserialize(response.content, "list[Vault]")[0]
 
-    def get_vaults(self) -> list[Vault]:
+    def get_vaults(self) -> List[Vault]:
         """Returns all vaults for service account set in client
 
         Raises:

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -50,7 +50,7 @@ class Client:
                 f"Unable to retrieve item. Received {response.status_code}\
                                      for {url} with message: {response.json().get('message')}"
             )
-        return self.deserialize(response.content, "File")
+        return self.serializer.deserialize(response.content, "File")
 
     def get_files(self, item_id: str, vault_id: str) -> List[File]:
         url = PathBuilder().vaults(vault_id).items(item_id).files().build()
@@ -62,7 +62,7 @@ class Client:
                 f"Unable to retrieve item. Received {response.status_code}\
                              for {url} with message: {response.json().get('message')}"
             )
-        return self.deserialize(response.content, "list[File]")
+        return self.serializer.deserialize(response.content, "list[File]")
 
     def get_file_content(self, file_id: str, item_id: str, vault_id: str, content_path: str = None) -> Union[bytes, str]:
         url = content_path
@@ -135,7 +135,7 @@ class Client:
                 f"Unable to retrieve item. Received {response.status_code}\
                      for {url} with message: {response.json().get('message')}"
             )
-        return self.deserialize(response.content, "Item")
+        return self.serializer.deserialize(response.content, "Item")
 
     def get_item_by_title(self, title: str, vault_id: str) -> Item:
         """Get a specific item by title
@@ -199,7 +199,7 @@ class Client:
                      for {url} with message: {response.json().get('message')}"
             )
 
-        return self.deserialize(response.content, "list[SummaryItem]")
+        return self.serializer.deserialize(response.content, "list[SummaryItem]")
 
     def delete_item(self, item_id: str, vault_id: str) -> None:
         """Deletes a specified item from a specified vault
@@ -246,7 +246,7 @@ class Client:
                 f"Unable to post item. Received {response.status_code}\
                     for {url} with message: {response.json().get('message')}"
             )
-        return self.deserialize(response.content, "Item")
+        return self.serializer.deserialize(response.content, "Item")
 
     def update_item(self, item_uuid: str, vault_id: str, item: Item) -> Item:
         """Update the specified item at the specified vault.
@@ -275,7 +275,7 @@ class Client:
                 f"Unable to post item. Received {response.status_code}\
                     for {url} with message: {response.json().get('message')}"
             )
-        return self.deserialize(response.content, "Item")
+        return self.serializer.deserialize(response.content, "Item")
 
     def get_vault(self, vault_id: str) -> Vault:
         """Returns the vault with the given vault_id
@@ -300,7 +300,7 @@ class Client:
                      for {url} with message {response.json().get('message')}"
             )
 
-        return self.deserialize(response.content, "Vault")
+        return self.serializer.deserialize(response.content, "Vault")
 
     def get_vault_by_title(self, name: str) -> Vault:
         """Returns the vault with the given name
@@ -354,7 +354,7 @@ class Client:
                      for {url} with message {response.json().get('message')}"
             )
 
-        return self.deserialize(response.content, "list[Vault]")
+        return self.serializer.deserialize(response.content, "list[Vault]")
 
     def build_request(self, method: str, path: str, body=None) -> httpx.Response:
         """Builds a http request


### PR DESCRIPTION
This PR aims to introduce type hints to return values for the client.

The changes are simple enough, simply adding the types as return type hints on each function in the client.

Working with the sdk is somewhat cumbersome, since I work in a typed project. The return types from the sdk are not great [see attachment], and properly resolving the typing of the responses from the sdk client should not really be necessary.

I've made a suggestion of how it could be done, but I had some trouble installing 3.7 to verify that this works as expected. I'm not sure if there were good reasons for leaving the types out, or if resolving the models leads to other problems.

<img width="679" alt="image" src="https://user-images.githubusercontent.com/632466/223780536-68cf0090-5248-4af5-9a7a-26843323e5fb.png">