### PR TITLE
enable filter use on get_items

### DIFF
--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -184,11 +184,12 @@ class Client:
         item_summary = self.deserialize(response.content, "list[SummaryItem]")[0]
         return self.get_item_by_id(item_summary.id, vault_id)
 
-    def get_items(self, vault_id: str):
+    def get_items(self, vault_id: str, filter_query=None):
         """Returns a list of item summaries for the specified vault
 
         Args:
             vault_id (str): The id of the vault in which to get the items from
+            filter_query (str): A optional query statement, eg `title eq foo.bar`
 
         Raises:
             FailedToRetrieveItemException: Thrown when a HTTP error is returned
@@ -197,7 +198,10 @@ class Client:
         Returns:
             List[SummaryItem]: A list of summarized items
         """
-        url = f"/v1/vaults/{vault_id}/items"
+        if filter_query:
+            url = f"/v1/vaults/{vault_id}/items?filter={filter_query}"
+        else:
+            url = f"/v1/vaults/{vault_id}/items"
 
         response = self.build_request("GET", url)
         try:

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -189,7 +189,7 @@ class Client:
 
         Args:
             vault_id (str): The id of the vault in which to get the items from
-            filter_query (str): A optional query statement, eg `title eq foo.bar`
+            filter_query (str): A optional query statement. `title eq foo.bar`
 
         Raises:
             FailedToRetrieveItemException: Thrown when a HTTP error is returned
@@ -198,10 +198,10 @@ class Client:
         Returns:
             List[SummaryItem]: A list of summarized items
         """
-        if filter_query:
-            url = f"/v1/vaults/{vault_id}/items?filter={filter_query}"
-        else:
+        if filter_query is None:
             url = f"/v1/vaults/{vault_id}/items"
+        else:
+            url = f"/v1/vaults/{vault_id}/items?filter={filter_query}"
 
         response = self.build_request("GET", url)
         try:


### PR DESCRIPTION
enables use of filter argument on get_items function
see https://developer.1password.com/docs/connect/connect-api-reference#list-items for usage options