### PR TITLE
Leave JSON encoding to HTTPX

### DIFF
--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -1,7 +1,6 @@
 """Python AsyncClient for connecting to 1Password Connect"""
 import httpx
 from httpx import HTTPError
-import json
 from typing import Dict, List, Union
 import os
 
@@ -361,8 +360,8 @@ class AsyncClient:
         """
 
         if body:
-            serialized_body = json.dumps(self.serializer.sanitize_for_serialization(body))
-            response = self.session.request(method, path, data=serialized_body)
+            sanitized_body = self.serializer.sanitize_for_serialization(body)
+            response = self.session.request(method, path, json=sanitized_body)
         else:
             response = self.session.request(method, path)
         return response

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -368,8 +368,8 @@ class Client:
         """
 
         if body:
-            serialized_body = json.dumps(self.serializer.sanitize_for_serialization(body))
-            response = self.session.request(method, path, data=serialized_body)
+            sanitized_body = self.serializer.sanitize_for_serialization(body)
+            response = self.session.request(method, path, json=sanitized_body)
         else:
             response = self.session.request(method, path)
         return response


### PR DESCRIPTION
HTTPX accepts JSON-encodable objects directly, there is no need for this
project to 'manually' encode the data to JSON.

By passing the body object directly to HTTPX, the library can then also handle
the appropriate client headers (Content-Type specifically).

Finally, this also neatly addresses the deprecation warning that HTTPX emits
whithout this change: `Use 'content=<...>' to upload raw bytes/text content.`.
The latter could also be avoided by using `content=serialized_body` instead of
`data=serialized_body`.
