### PR TITLE
Update example main.py to handle 'n' input

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -48,12 +48,12 @@ print(steps.steps["step4"])
 print(steps.steps["confirmation"])
 answer = input()
 
-while answer != ('y' or 'n'):
+while answer.lower() not in {'y', 'n'}:
     print(steps.steps["confirmation2"])
     answer = input()
 
 # DELETE THE ITEM FROM THE VAULT
-if answer == 'y':
+if answer.lower() == 'y':
     client.delete_item(posted_item.id, default_vault)
     print(steps.steps["step5"])
 


### PR DESCRIPTION
## Overview

The `example/main.py` script currently doesn't properly accept `n` as an input when prompted with `Would you like to delete the newly created item from your vault? (y/n)`

## Type of change

Bug fix

## Related Issue(s)

N/A

## How To Test

1. Run the [Python Connect SDK example](https://github.com/1Password/connect-sdk-python/blob/main/example/README.md)
2. When you see `Would you like to delete the newly created item from your vault? (y/n)`, enter `n`

### Current Behavior

`Your answer should be either 'y' or 'n'. Would you like to delete the newly created item from your vault? (y/n)` is continuously prompted, until `y` is entered.

### New (Fixed) Behavior

The item is not deleted from the vault and the example script terminates. Both uppercase `Y/N` and lowercase `y/n` are accepted.

