### PR TITLE
Cleaner client constructors

### DIFF
--- a/src/onepasswordconnectsdk/__init__.py
+++ b/src/onepasswordconnectsdk/__init__.py
@@ -6,3 +6,5 @@ from onepasswordconnectsdk.config import load
 from onepasswordconnectsdk.config import load_dict
 from onepasswordconnectsdk.client import new_client
 from onepasswordconnectsdk.client import new_client_from_environment
+from onepasswordconnectsdk.async_client import new_async_client
+from onepasswordconnectsdk.async_client import new_async_client_from_environment

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -16,7 +16,6 @@ from onepasswordconnectsdk.models import Item, ItemVault
 from onepasswordconnectsdk.models.constants import CONNECT_HOST_ENV_VARIABLE
 
 ENV_SERVICE_ACCOUNT_JWT_VARIABLE = "OP_CONNECT_TOKEN"
-ENV_IS_ASYNC_CLIENT = "OP_CONNECT_CLIENT_ASYNC"
 
 
 class Client:

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -4,7 +4,6 @@ from httpx import HTTPError
 import json
 import os
 
-from onepasswordconnectsdk.async_client import AsyncClient
 from onepasswordconnectsdk.serializer import Serializer
 from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder
 from onepasswordconnectsdk.errors import (
@@ -380,22 +379,19 @@ class Client:
         return self.serializer.sanitize_for_serialization(obj)
 
 
-def new_client(url: str, token: str, is_async: bool = False):
+def new_client(url: str, token: str) -> Client:
     """Builds a new client for interacting with 1Password Connect
     Parameters:
     url: The url of the 1Password Connect API
     token: The 1Password Service Account token
-    is_async: Initialize async or sync client
 
     Returns:
     Client: The 1Password Connect client
     """
-    if is_async:
-        return AsyncClient(url, token)
     return Client(url, token)
 
 
-def new_client_from_environment(url: str = None):
+def new_client_from_environment(url: str = None) -> Client:
     """Builds a new client for interacting with 1Password Connect
     using the OP_TOKEN environment variable
 
@@ -407,7 +403,6 @@ def new_client_from_environment(url: str = None):
     Client: The 1Password Connect client
     """
     token = os.environ.get(ENV_SERVICE_ACCOUNT_JWT_VARIABLE)
-    is_async = os.environ.get(ENV_IS_ASYNC_CLIENT) == "True"
 
     if url is None:
         url = os.environ.get(CONNECT_HOST_ENV_VARIABLE)
@@ -422,4 +417,4 @@ def new_client_from_environment(url: str = None):
             f"{ENV_SERVICE_ACCOUNT_JWT_VARIABLE} variable"
         )
 
-    return new_client(url, token, is_async)
+    return new_client(url, token)

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -397,7 +397,6 @@ def new_client_from_environment(url: str = None) -> Client:
 
     Parameters:
     url: The url of the 1Password Connect API
-    token: The 1Password Service Account token
 
     Returns:
     Client: The 1Password Connect client

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -1,6 +1,6 @@
 import pytest
 from httpx import Response
-from onepasswordconnectsdk import client, models
+from onepasswordconnectsdk import async_client, client, models
 
 VAULT_ID = "hfnjvi6aymbsnfc2xeeoheizda"
 VAULT_TITLE = "VaultA"
@@ -9,7 +9,7 @@ ITEM_TITLE = "Test Login"
 HOST = "https://mock_host"
 TOKEN = "jwt_token"
 SS_CLIENT = client.new_client(HOST, TOKEN)
-SS_CLIENT_ASYNC = client.new_client(HOST, TOKEN, True)
+SS_CLIENT_ASYNC = async_client.new_async_client(HOST, TOKEN)
 
 
 def test_get_item_by_id(respx_mock):

--- a/src/tests/test_client_vaults.py
+++ b/src/tests/test_client_vaults.py
@@ -1,13 +1,13 @@
 import pytest
 from httpx import Response
-from onepasswordconnectsdk import client
+from onepasswordconnectsdk import async_client, client
 
 VAULT_ID = "hfnjvi6aymbsnfc2xeeoheizda"
 VAULT_NAME = "VaultA"
 HOST = "https://mock_host"
 TOKEN = "jwt_token"
 SS_CLIENT = client.new_client(HOST, TOKEN)
-SS_CLIENT_ASYNC = client.new_client(HOST, TOKEN, True)
+SS_CLIENT_ASYNC = async_client.new_async_client(HOST, TOKEN)
 
 
 def test_get_vaults(respx_mock):


### PR DESCRIPTION
This PR aims to declutter the constructor for new clients.

I've removed all code related to AsyncClient from client.py, and allowed you to directly make AsyncClient. This does mean it's a breaking change, but one that is easily caught by tests or type checkers. 

There are a couple of reasons for this:
* When typing up the client (PR #68), the reasoning was that there should be less ambiguity about which types we are getting. Having `new_client()` making both types means that a typed project doesn't know if it has a Client or AsyncClient, and it has to be validated before use.
* Allowing developers to specifically choose sync or async clients is just better, especially if for some reason one would use both, so that type checkers can validate properly.
* Removed the environment variable support for making sync/async client, since it makes no sense to configure this on runtime. The clients are not interchangeable, you need to await async calls, and you either programmed for this or you didn't.

Finally, I will concede that it's not the greatest idea to repeat the code for getting the env vars and validating them in both constructors, it could be moved to some sort of utility function. I can do that if desireable, but in this case it's not a great chance for reusability.