### PR TITLE
[Feat] Allow custom timeout using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Check the [Python Connect SDK Example](example/README.md) to see an example of i
    2.1 If you need a higher timeout on the client requests you can export `OP_CLIENT_REQ_TIMEOUT` environment variable:
    ```sh
    # set the timeout to 90 seconds
-   export OP_CLIENT_REQ_TIMEOUT=90
+   export OP_CLIENT_REQUEST_TIMEOUT=90
    ```
 
 3. Use the SDK:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Check the [Python Connect SDK Example](example/README.md) to see an example of i
    export OP_CONNECT_TOKEN=<your-connect-token>
    ```
    
-   2.1 If you need a higher timeout on the client requests you can export `OP_CLIENT_REQ_TIMEOUT` environment variable:
+   2.1 If you need a higher timeout on the client requests you can export `OP_CLIENT_REQUEST_TIMEOUT` environment variable:
    ```sh
    # set the timeout to 90 seconds
    export OP_CLIENT_REQUEST_TIMEOUT=90

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Check the [Python Connect SDK Example](example/README.md) to see an example of i
    export OP_CONNECT_HOST=<your-connect-host> && \
    export OP_CONNECT_TOKEN=<your-connect-token>
    ```
+   
+   2.1 If you need a higher timeout on the client requests you can export `OP_CLIENT_REQ_TIMEOUT` environment variable:
+   ```sh
+   # set the timeout to 90 seconds
+   export OP_CLIENT_REQ_TIMEOUT=90
+   ```
 
 3. Use the SDK:
 

--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -1,26 +1,16 @@
 """Python AsyncClient for connecting to 1Password Connect"""
 import httpx
-from httpx import HTTPError, USE_CLIENT_DEFAULT
+from httpx import HTTPError
 from typing import Dict, List, Union
 import os
 
-from httpx._client import UseClientDefault
-
 from onepasswordconnectsdk.serializer import Serializer
-from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder
+from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder, get_timeout
 from onepasswordconnectsdk.errors import (
     FailedToRetrieveItemException,
     FailedToRetrieveVaultException,
 )
 from onepasswordconnectsdk.models import File, Item, ItemVault, SummaryItem, Vault
-
-
-ENV_CLIENT_REQ_TIMEOUT = "OP_CONNECT_CLIENT_REQ_TIMEOUT"
-
-
-def get_timeout() -> Union[int, UseClientDefault]:
-    timeout = int(os.getenv(ENV_CLIENT_REQ_TIMEOUT, 0))
-    return timeout if timeout else USE_CLIENT_DEFAULT
 
 
 class AsyncClient:

--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -1,8 +1,10 @@
 """Python AsyncClient for connecting to 1Password Connect"""
 import httpx
-from httpx import HTTPError
+from httpx import HTTPError, USE_CLIENT_DEFAULT
 from typing import Dict, List, Union
 import os
+
+from httpx._client import UseClientDefault
 
 from onepasswordconnectsdk.serializer import Serializer
 from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder
@@ -11,6 +13,14 @@ from onepasswordconnectsdk.errors import (
     FailedToRetrieveVaultException,
 )
 from onepasswordconnectsdk.models import File, Item, ItemVault, SummaryItem, Vault
+
+
+ENV_CLIENT_REQ_TIMEOUT = "OP_CONNECT_CLIENT_REQ_TIMEOUT"
+
+
+def get_timeout() -> Union[int, UseClientDefault]:
+    timeout = int(os.getenv(ENV_CLIENT_REQ_TIMEOUT, 0))
+    return timeout if timeout else USE_CLIENT_DEFAULT
 
 
 class AsyncClient:
@@ -24,7 +34,8 @@ class AsyncClient:
         self.serializer = Serializer()
 
     def create_session(self, url: str, token: str) -> httpx.AsyncClient:
-        return httpx.AsyncClient(base_url=url, headers=self.build_headers(token))
+        # import here to avoid circular import
+        return httpx.AsyncClient(base_url=url, headers=self.build_headers(token), timeout=get_timeout())
 
     def build_headers(self, token: str) -> Dict[str, str]:
         return build_headers(token)

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -1,11 +1,11 @@
 """Python Client for connecting to 1Password Connect"""
 import httpx
-from httpx import HTTPError
+from httpx import HTTPError, USE_CLIENT_DEFAULT
 import json
 from typing import Dict, List, Union
 import os
 
-from onepasswordconnectsdk.async_client import AsyncClient
+from onepasswordconnectsdk.async_client import AsyncClient, get_timeout
 from onepasswordconnectsdk.serializer import Serializer
 from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder
 from onepasswordconnectsdk.errors import (
@@ -32,7 +32,7 @@ class Client:
         self.serializer = Serializer()
 
     def create_session(self, url: str, token: str) -> httpx.Client:
-        return httpx.Client(base_url=url, headers=self.build_headers(token))
+        return httpx.Client(base_url=url, headers=self.build_headers(token), timeout=get_timeout())
 
     def build_headers(self, token: str) -> Dict[str, str]:
         return build_headers(token)

--- a/src/onepasswordconnectsdk/client.py
+++ b/src/onepasswordconnectsdk/client.py
@@ -5,9 +5,9 @@ import json
 from typing import Dict, List, Union
 import os
 
-from onepasswordconnectsdk.async_client import AsyncClient, get_timeout
+from onepasswordconnectsdk.async_client import AsyncClient
 from onepasswordconnectsdk.serializer import Serializer
-from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder
+from onepasswordconnectsdk.utils import build_headers, is_valid_uuid, PathBuilder, get_timeout
 from onepasswordconnectsdk.errors import (
     FailedToRetrieveItemException,
     FailedToRetrieveVaultException,

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -1,4 +1,11 @@
+import os
+from typing import Union
+
+from httpx import USE_CLIENT_DEFAULT
+from httpx._client import UseClientDefault
+
 UUIDLength = 26
+ENV_CLIENT_REQUEST_TIMEOUT = "OP_CONNECT_CLIENT_REQ_TIMEOUT"
 
 
 def is_valid_uuid(uuid):
@@ -59,3 +66,9 @@ class PathBuilder:
             self.path += f"/{path_chunk}"
         if query is not None:
             self.path += f"?{query}"
+
+
+def get_timeout() -> Union[int, UseClientDefault]:
+    """Get the timeout to be used in the HTTP Client"""
+    timeout = int(os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0))
+    return timeout if timeout else USE_CLIENT_DEFAULT

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from httpx import Response
 from onepasswordconnectsdk import client, models
-from onepasswordconnectsdk.async_client import ENV_CLIENT_REQ_TIMEOUT
+from onepasswordconnectsdk.utils import ENV_CLIENT_REQUEST_TIMEOUT
 
 VAULT_ID = "hfnjvi6aymbsnfc2xeeoheizda"
 VAULT_TITLE = "VaultA"
@@ -447,13 +447,13 @@ def generate_full_item():
 
 
 def test_set_timeout_using_env_variable():
-    with mock.patch.dict(os.environ, {ENV_CLIENT_REQ_TIMEOUT: '120'}):
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '120'}):
         client_instance = client.new_client(HOST, TOKEN)
         assert client_instance.session.timeout.read == 120
 
 
 @pytest.mark.asyncio
 def test_set_timeout_using_env_variable_async():
-    with mock.patch.dict(os.environ, {ENV_CLIENT_REQ_TIMEOUT: '120'}):
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '120'}):
         client_instance = client.new_client(HOST, TOKEN, is_async=True)
         assert client_instance.session.timeout.read == 120

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -1,6 +1,10 @@
+import os
 import pytest
+from unittest import mock
+
 from httpx import Response
 from onepasswordconnectsdk import client, models
+from onepasswordconnectsdk.async_client import ENV_CLIENT_REQ_TIMEOUT
 
 VAULT_ID = "hfnjvi6aymbsnfc2xeeoheizda"
 VAULT_TITLE = "VaultA"
@@ -440,3 +444,16 @@ def generate_full_item():
                                                 id="Section_47DC4DDBF26640AB8B8618DA36D5A499"))],
                        sections=[models.Section(id="id", label="label")])
     return item
+
+
+def test_set_timeout_using_env_variable():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQ_TIMEOUT: '120'}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read == 120
+
+
+@pytest.mark.asyncio
+def test_set_timeout_using_env_variable_async():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQ_TIMEOUT: '120'}):
+        client_instance = client.new_client(HOST, TOKEN, is_async=True)
+        assert client_instance.session.timeout.read == 120


### PR DESCRIPTION
For some use cases, for instance, when there's a VPN between the computer running the client and the 1password servers the default timeout may not be enough. In those cases the user receives a `httpx.ConnectTimeout` exception.

This PR will allow the user to define a custom timeout by using an environment variable.