### PR TITLE
Fixed example for onepasswordconnectsdk.load_dict()

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -120,14 +120,17 @@ CONFIG = {
     "database": {
         "opitem": "My database item",
         "opfield": ".database",
+        "opvault": "some_vault_id",
     },
     "username": {
         "opitem": "My database item",
         "opfield": ".username",
+        "opvault": "some_vault_id",
     },
     "password": {
         "opitem": "My database item",
         "opfield": ".password",
+        "opvault": "some_vault_id",
     },
 }
 


### PR DESCRIPTION
The example for onepasswordconnectsdk.load_dict() in USAGE.md was inaccurate and would result in errors. This has now been corrected and will now actually work. This addresses #97.