### PR TITLE
Fix/timeout

### DIFF
--- a/src/onepasswordconnectsdk/async_client.py
+++ b/src/onepasswordconnectsdk/async_client.py
@@ -24,7 +24,6 @@ class AsyncClient:
         self.serializer = Serializer()
 
     def create_session(self, url: str, token: str) -> httpx.AsyncClient:
-        # import here to avoid circular import
         return httpx.AsyncClient(base_url=url, headers=self.build_headers(token), timeout=get_timeout())
 
     def build_headers(self, token: str) -> Dict[str, str]:

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -68,11 +68,11 @@ class PathBuilder:
 
 def get_timeout() -> Timeout:
     """Get the timeout to be used in the HTTP Client"""
-    raw_timeout = os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0.0)
+    raw_timeout = os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, '0.0')
     if raw_timeout == 'None':
         return Timeout(None)  # disable all timeouts
-    elif raw_timeout == '':
-        return DEFAULT_TIMEOUT_CONFIG
-    else:
+    elif raw_timeout.isnumeric():
         timeout = float(raw_timeout)
         return timeout if timeout else DEFAULT_TIMEOUT_CONFIG
+    else:
+        return DEFAULT_TIMEOUT_CONFIG

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -75,5 +75,4 @@ def get_timeout() -> Timeout:
         return DEFAULT_TIMEOUT_CONFIG
     else:
         timeout = float(raw_timeout)
-        t = timeout if timeout else DEFAULT_TIMEOUT_CONFIG
-        return t
+        return timeout if timeout else DEFAULT_TIMEOUT_CONFIG

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -1,8 +1,6 @@
 import os
-from typing import Union
 
-from httpx import USE_CLIENT_DEFAULT
-from httpx._client import UseClientDefault
+from httpx._client import DEFAULT_TIMEOUT_CONFIG, Timeout
 
 UUIDLength = 26
 ENV_CLIENT_REQUEST_TIMEOUT = "OP_CONNECT_CLIENT_REQ_TIMEOUT"
@@ -68,7 +66,7 @@ class PathBuilder:
             self.path += f"?{query}"
 
 
-def get_timeout() -> Union[int, UseClientDefault]:
+def get_timeout() -> Timeout:
     """Get the timeout to be used in the HTTP Client"""
-    timeout = int(os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0))
-    return timeout if timeout else USE_CLIENT_DEFAULT
+    timeout = float(os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0))
+    return timeout if timeout else DEFAULT_TIMEOUT_CONFIG

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -68,5 +68,12 @@ class PathBuilder:
 
 def get_timeout() -> Timeout:
     """Get the timeout to be used in the HTTP Client"""
-    timeout = float(os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0))
-    return timeout if timeout else DEFAULT_TIMEOUT_CONFIG
+    raw_timeout = os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0.0)
+    if raw_timeout == 'None':
+        return Timeout(None)  # disable all timeouts
+    elif raw_timeout == '':
+        return DEFAULT_TIMEOUT_CONFIG
+    else:
+        timeout = float(raw_timeout)
+        t = timeout if timeout else DEFAULT_TIMEOUT_CONFIG
+        return t

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -463,3 +463,21 @@ def test_set_timeout_using_env_variable_async():
     with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '120'}):
         client_instance = client.new_client(HOST, TOKEN, is_async=True)
         assert client_instance.session.timeout.read == 120
+
+
+def test_disable_all_timeouts():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: 'None'}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read is None
+
+
+def test_env_client_request_timeout_env_var_is_empty_string():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: ''}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read
+
+
+def test_env_client_request_timeout_env_var_is_zero():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '0'}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -477,6 +477,18 @@ def test_env_client_request_timeout_env_var_is_empty_string():
         assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read
 
 
+def test_env_client_request_timeout_env_var_is_single_space_string():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: ' '}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read
+
+
+def test_env_client_request_timeout_env_var_is_not_numeric_string():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: 'abc'}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read
+
+
 def test_env_client_request_timeout_env_var_is_zero():
     with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '0'}):
         client_instance = client.new_client(HOST, TOKEN)

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -3,6 +3,7 @@ import pytest
 from unittest import mock
 
 from httpx import Response
+from httpx._client import DEFAULT_TIMEOUT_CONFIG
 from onepasswordconnectsdk import client, models
 from onepasswordconnectsdk.utils import ENV_CLIENT_REQUEST_TIMEOUT
 
@@ -444,6 +445,11 @@ def generate_full_item():
                                                 id="Section_47DC4DDBF26640AB8B8618DA36D5A499"))],
                        sections=[models.Section(id="id", label="label")])
     return item
+
+
+def test_default_timeout():
+    client_instance = client.new_client(HOST, TOKEN)
+    assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read
 
 
 def test_set_timeout_using_env_variable():

--- a/src/tests/test_client_items.py
+++ b/src/tests/test_client_items.py
@@ -493,3 +493,9 @@ def test_env_client_request_timeout_env_var_is_zero():
     with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '0'}):
         client_instance = client.new_client(HOST, TOKEN)
         assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read
+
+
+def test_env_client_request_timeout_env_var_is_negative_number():
+    with mock.patch.dict(os.environ, {ENV_CLIENT_REQUEST_TIMEOUT: '-10'}):
+        client_instance = client.new_client(HOST, TOKEN)
+        assert client_instance.session.timeout.read == DEFAULT_TIMEOUT_CONFIG.read


### PR DESCRIPTION
This PR fixes the issue when Client throws an error if `OP_CONNECT_CLIENT_REQ_TIMEOUT` env var is not set.

In addition `get_timeout` function is improved to cover the following cases:
- when `export OP_CONNECT_CLIENT_REQ_TIMEOUT=None` - it disables all the timeouts (behaves the same as [described in to documentation](https://www.python-httpx.org/advanced/timeouts/))
- when `export OP_CONNECT_CLIENT_REQ_TIMEOUT=''` - it sets default timeout 5s.
- when `export OP_CONNECT_CLIENT_REQ_TIMEOUT=0` -it sets default timeout 5s.


### Testing steps
**The env var is set**
1. Up 1Password Connect server.
2. Put this to `main.py` file 
```
from onepasswordconnectsdk.client import AsyncClient, Client
from onepasswordconnectsdk import new_client

client: Client = new_client(host, token) #put your token an host
vaults = client.get_vaults()
print(vaults)
```
3. `export OP_CONNECT_CLIENT_REQ_TIMEOUT=30`
4. run `python main.py`

**Should use default timeout**
1. Up 1Password Connect server.
2. Put this to `main.py` file 
```
from onepasswordconnectsdk.client import AsyncClient, Client
from onepasswordconnectsdk import new_client

client: Client = new_client(host, token) #put your token an host
vaults = client.get_vaults()
print(vaults)
```
3. run `python main.py`

Resolves #104 