### PR TITLE
[Fix] OP_CONNECT_CLIENT_REQUEST_TIMEOUT default value was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Check the [Python Connect SDK Example](example/README.md) to see an example of i
    export OP_CONNECT_TOKEN=<your-connect-token>
    ```
    
-   2.1 If you need a higher timeout on the client requests you can export `OP_CLIENT_REQUEST_TIMEOUT` environment variable:
+   2.1 If you need a higher timeout on the client requests you can export `OP_CONNECT_CLIENT_REQUEST_TIMEOUT` environment variable:
    ```sh
    # set the timeout to 90 seconds
-   export OP_CLIENT_REQUEST_TIMEOUT=90
+   export OP_CONNECT_CLIENT_REQUEST_TIMEOUT=90
    ```
 
 3. Use the SDK:

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -1,7 +1,7 @@
 import os
 from typing import Union
 
-from httpx._config import DEFAULT_TIMEOUT_CONFIG
+from httpx._config import DEFAULT_TIMEOUT_CONFIG, Timeout
 
 UUIDLength = 26
 ENV_CLIENT_REQUEST_TIMEOUT = "OP_CONNECT_CLIENT_REQUEST_TIMEOUT"
@@ -67,7 +67,7 @@ class PathBuilder:
             self.path += f"?{query}"
 
 
-def get_timeout() -> Union[int, DEFAULT_TIMEOUT_CONFIG]:
+def get_timeout() -> Union[int, Timeout]:
     """Get the timeout to be used in the HTTP Client"""
     timeout = int(os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0))
     return timeout if timeout else DEFAULT_TIMEOUT_CONFIG

--- a/src/onepasswordconnectsdk/utils.py
+++ b/src/onepasswordconnectsdk/utils.py
@@ -1,11 +1,10 @@
 import os
 from typing import Union
 
-from httpx import USE_CLIENT_DEFAULT
-from httpx._client import UseClientDefault
+from httpx._config import DEFAULT_TIMEOUT_CONFIG
 
 UUIDLength = 26
-ENV_CLIENT_REQUEST_TIMEOUT = "OP_CONNECT_CLIENT_REQ_TIMEOUT"
+ENV_CLIENT_REQUEST_TIMEOUT = "OP_CONNECT_CLIENT_REQUEST_TIMEOUT"
 
 
 def is_valid_uuid(uuid):
@@ -68,7 +67,7 @@ class PathBuilder:
             self.path += f"?{query}"
 
 
-def get_timeout() -> Union[int, UseClientDefault]:
+def get_timeout() -> Union[int, DEFAULT_TIMEOUT_CONFIG]:
     """Get the timeout to be used in the HTTP Client"""
     timeout = int(os.getenv(ENV_CLIENT_REQUEST_TIMEOUT, 0))
-    return timeout if timeout else USE_CLIENT_DEFAULT
+    return timeout if timeout else DEFAULT_TIMEOUT_CONFIG


### PR DESCRIPTION
The default value for env variable `OP_CONNECT_CLIENT_REQUEST_TIMEOUT` was using a wrong default value.
This should be fixed in this PR.