### PR TITLE
Fix the env var name to override default http client timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Check the [Python Connect SDK Example](example/README.md) to see an example of i
    export OP_CONNECT_TOKEN=<your-connect-token>
    ```
    
-   2.1 If you need a higher timeout on the client requests you can export `OP_CLIENT_REQUEST_TIMEOUT` environment variable:
+   2.1 If you need a higher timeout on the client requests you can export `OP_CONNECT_CLIENT_REQ_TIMEOUT` environment variable:
    ```sh
    # set the timeout to 90 seconds
-   export OP_CLIENT_REQUEST_TIMEOUT=90
+   export OP_CONNECT_CLIENT_REQ_TIMEOUT=90
    ```
 
 3. Use the SDK:


### PR DESCRIPTION
This PR fixes the env var name to override default http client timeouts. Users should set `OP_CONNECT_CLIENT_REQ_TIMEOUT` to override the timeout.