### PR TITLE
Remove codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,3 @@ jobs:
       - name: Test
         run: |
           poetry run pytest src/tests --cov=./ --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Currently no PRs can be merged since the codecov step doesn't work anymore. Fixing that is a lengthy process, so to temporarily unblock important PRs from being merged (i.e. #116, #114, #107), we will remove this from our pipeline.