### PR TITLE
Improve workflow permissions

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,12 +1,14 @@
 name: Check signed commits in PR
+
 on: pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   build:
     name: Check signed commits in PR
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check signed commits in PR

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,8 +1,12 @@
+name: Open Release PR for review
+
 on:
   create:
     branches:
 
-name: Open Release PR for review
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   # This job is necessary because GitHub does not (yet) support

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches: main
     types: closed
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,12 @@
 name: Tests
-permissions:
-  contents: read
+
 on:
   push:
     branches: main
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

This PR explicitly states the permissions needed for each of the repo's workflows. 

## Thought process

Since our project has been created before February 2023, we have the more permissive permission `write-all` set for the `GITHUB_TOKEN` used by the workflow. Therefore, to apply the principle of least privilege, we now explicitly specify the permisisons needed for each workflow (also mentioned in the Code scan alerts).

The workflows that didn't have any permissions explicitly set were `release` and `release-pr`. Here's how the permissions for these two were determined:
- `release` - It builds, publishes to PyPi, creates a new tag and makes a new release on GitHub with the new tag. Since the workflow makes changes to the repo, it needs `contents: write`.
- `release-pr` - It creates a PR if there's not one already for a branch with a specific format. For that it needs `contents: read` (it doesn't make changes to the branch) and `pull_requests: write`.

This addressed the following Code scan security alerts:
- https://github.com/1Password/connect-sdk-python/security/code-scanning/3
- https://github.com/1Password/connect-sdk-python/security/code-scanning/2
- https://github.com/1Password/connect-sdk-python/security/code-scanning/1

In addition, I've applied the same styling format for all current workflows for consistency.