### PR TITLE
Use `rest` object to check PRs list in a workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,7 +31,7 @@ jobs:
 
             if(!releaseBranchName) { return false }
 
-            const {data: prs} = await github.pulls.list({
+            const {data: prs} = await github.rest.pulls.list({
                 ...context.repo,
                 state: 'open',
                 head: `1Password:${releaseBranchName}`,


### PR DESCRIPTION
This PR fixes release PR workflow after it was updated to use `actions/github-script@v8`