### PR TITLE
fix: return type annotation for load_dict

### DIFF
--- a/src/onepasswordconnectsdk/config.py
+++ b/src/onepasswordconnectsdk/config.py
@@ -49,14 +49,14 @@ class ClientConfig:
             'headers': headers,
             'timeout': timeout,
         }
-        
+
         # Set verify from ca_file first
         if self.ca_file:
             args['verify'] = self.ca_file
-            
+
         # Allow httpx_options (including verify) to override
         args.update(self.httpx_options)
-            
+
         return args
 
 
@@ -100,7 +100,7 @@ def load_dict(client: "Client", config: dict):
     """
 
     items: dict = {}
-    config_values: Dict[str, str] = {}
+    config_values: Dict[str, Optional[str]] = {}
 
     for field, tags in config.items():
         item_tag = tags.get(ITEM_TAG)
@@ -236,7 +236,7 @@ def _set_values_for_item(
                 section_id = field.section.id
             except AttributeError:
                 section_id = None
-                
+
             if field.label == path_parts[1]:
                 if (
                     section_id is None

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -73,6 +73,31 @@ def test_load_dict(respx_mock):
     assert config_with_values['password'] == PASSWORD_VALUE
 
 
+def test_load_dict_empty_field_returns_none(respx_mock):
+    config_dict = {
+        "username": {
+            "opitem": ITEM_NAME1,
+            "opfield": ".username",
+            "opvault": VAULT_ID
+        },
+        "empty": {
+            "opitem": ITEM_NAME1,
+            "opfield": ".empty_field",
+            "opvault": VAULT_ID
+        }
+    }
+
+    respx_mock.get(f"v1/vaults/{VAULT_ID}/items?filter=title eq \"{ITEM_NAME1}\"").mock(
+        return_value=Response(200, json=[item_with_empty_field]))
+    respx_mock.get(f"v1/vaults/{VAULT_ID}/items/{ITEM_ID1}").mock(
+        return_value=Response(200, json=item_with_empty_field))
+
+    config_with_values = onepasswordconnectsdk.load_dict(SS_CLIENT, config_dict)
+
+    assert config_with_values['username'] == USERNAME_VALUE
+    assert config_with_values['empty'] is None
+
+
 item = {
     "id": ITEM_ID1,
     "title": ITEM_NAME1,
@@ -99,6 +124,26 @@ item = {
             "id": "username",
             "label": "username",
             "value": USERNAME_VALUE
+        }
+    ]
+}
+
+item_with_empty_field = {
+    "id": ITEM_ID1,
+    "title": ITEM_NAME1,
+    "vault": {
+        "id": VAULT_ID
+    },
+    "category": "LOGIN",
+    "fields": [
+        {
+            "id": "username",
+            "label": "username",
+            "value": USERNAME_VALUE
+        },
+        {
+            "id": "empty_field",
+            "label": "empty_field"
         }
     ]
 }


### PR DESCRIPTION
### Summary
`load_dict` returns `None` for 1Password fields that exist but have no value, so the internal annotation `Dict[str, str]` was inaccurate. Updates it to `Dict[str, Optional[str]]` to match runtime behaviour and adds a test covering the empty-field case.

Resolves: https://github.com/1Password/connect-sdk-python/issues/67